### PR TITLE
Improved deploy time by changing how access tokens are generated

### DIFF
--- a/aws/cicdont/README.md
+++ b/aws/cicdont/README.md
@@ -31,9 +31,9 @@ terraform apply
 
 You will be prompted with two questions. The first is a consent related to the costs of the CTF (Again, these should be minimal however the environment should still be taken down when you're finished with it). The second is asking your player name. **Please do not use special characters in the name, only upper and lower case letters**. This will be used in the game.
 
-**Please note: It will take around 15 minutes for all the infrastructure to be deployed and ready.** This 15 minute timer begins **AFTER** the Terraform apply has completed. This time is used to install all the software, create the NPCs, etc.
+**Please note: It will take around 10 minutes for all the infrastructure to be deployed and ready.** This 10 minute timer begins **AFTER** the Terraform apply has completed. This time is used to install all the software, create the NPCs, etc.
 
-**Also note: To be able to access the vulnerable instance, Terraform will attempt to determine your public ip address and create a security group that only that ip address can access.** If you cannot access the target_ip (explained below) after 15 minutes, check the AWS console for a security group named `allow_http` and ensure that it's configuration would allow you to reach it. 
+**Also note: To be able to access the vulnerable instance, Terraform will attempt to determine your public ip address and create a security group that only that ip address can access.** If you cannot access the target_ip (explained below) after 10 minutes, check the AWS console for a security group named `allow_http` and ensure that it's configuration would allow you to reach it. 
 
 To destroy the CTF environment run the Terraform destroy command.
 
@@ -57,13 +57,13 @@ To access the attackbox, you can ssh using your player username and password.
 ssh <player username>@<attackbox IP>
 ```
 
-**It will take approximately 15 minutes for all the infrastructure to finish deploying.** If you'd like to test if it's finished, you should be able to access a particular endpoint. If you get an error, it's not finished. If instead you land at a profile page, you can be assured it's done.
+**It will take approximately 10 minutes for all the infrastructure to finish deploying.** If you'd like to test if it's finished, you should be able to access a particular endpoint. If you get an error, it's not finished. If instead you land at a profile page, you can be assured it's done.
 
 ```
 http://<target IP>/<player username>
 ```
 
-**Please Note: To be able to access the vulnerable instance, Terraform will attempt to determine your public ip address and create a security group that only that ip address can access.** If you cannot access the target_ip (explained below) after 15 minutes, check the AWS console for a security group named `allow_http` and ensure that it's configuration would allow you to reach it. 
+**Please Note: To be able to access the vulnerable instance, Terraform will attempt to determine your public ip address and create a security group that only that ip address can access.** If you cannot access the target_ip (explained below) after 10 minutes, check the AWS console for a security group named `allow_http` and ensure that it's configuration would allow you to reach it. 
 
 If you see any references to `gamemaster`, please ignore it. Those scripts are used to simulate the NPCs and have them complete their lore tasks. It is unrelated to the challenge.
 
@@ -99,11 +99,11 @@ After this, you will be asked if you'd like to perform the deployment. Answer wi
 The Terraform deployment will begin.
 
 ### Wait
-You will now need to wait 15 minutes for the deployment to finish. Please note, that 15 minute timer starts **AFTER** you get the "Apply complete" notification. 
+You will now need to wait 10 minutes for the deployment to finish. Please note, that 10 minute timer starts **AFTER** you get the "Apply complete" notification. 
 
 ![Output](screenshots/output.png)
 
-Does it really take 15 minutes? Yes, it takes a little bit to get everything setup. You can take this time to get familiar with your attackbox. This is an EC2 instance you can use for whatever you need during the CTF, particularly to catch shells.
+Does it really take 10 minutes? Yes, it takes a little bit to get everything setup. You can take this time to get familiar with your attackbox. This is an EC2 instance you can use for whatever you need during the CTF, particularly to catch shells.
 
 You can ssh into the box using your username and password
 
@@ -112,7 +112,7 @@ ssh <player_username>@<target_ip>
 ```
 
 ### Getting Started
-After waiting those 15 minutes, you finally have a target. You can navigate to the target_ip to see a GitLab instance. Log in using your player username and password.
+After waiting those 10 minutes, you finally have a target. You can navigate to the target_ip to see a GitLab instance. Log in using your player username and password.
 
 ![Home](screenshots/home.png)
 

--- a/aws/cicdont/gamemaster/gamemaster.sh
+++ b/aws/cicdont/gamemaster/gamemaster.sh
@@ -4,13 +4,6 @@
 # Answer: This is all the "behind the scenes" activities to create the NPCs, along with their comments and what not.
 # If you've somehow found this script while playing the CTF you can safely ignore it. Or use it to your advantage, idk.
 
-ashley_token=$(openssl rand -hex 20)
-daniel_token=$(openssl rand -hex 20)
-sam_token=$(openssl rand -hex 20)
-mark_token=$(openssl rand -hex 20)
-carmen_token=$(openssl rand -hex 20)
-louis_token=$(openssl rand -hex 20)
-
 # Create ashley
 ashley_id=$(curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/users?email=ashley@cloud.local&username=ashley&name=ashley&force_random_password=true&skip_confirmation=true" | jq -r '.id')
 # Create mark
@@ -25,12 +18,12 @@ louis_id=$(curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/users?em
 daniel_id=$(curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/users?email=daniel@cloud.local&username=daniel&name=daniel&force_random_password=true&skip_confirmation=true" | jq -r '.id')
 
 # Create ashley access token
-gitlab-rails runner "token = User.find_by_username('ashley').personal_access_tokens.create(scopes: [:api], name: 'automation'); token.set_token('$ashley_token'); token.save!"
-gitlab-rails runner "token = User.find_by_username('daniel').personal_access_tokens.create(scopes: [:api], name: 'danielauto'); token.set_token('$daniel_token'); token.save!"
-gitlab-rails runner "token = User.find_by_username('sam').personal_access_tokens.create(scopes: [:api], name: 'samauto'); token.set_token('$sam_token'); token.save!"
-gitlab-rails runner "token = User.find_by_username('mark').personal_access_tokens.create(scopes: [:api], name: 'markauto'); token.set_token('$mark_token'); token.save!"
-gitlab-rails runner "token = User.find_by_username('carmen').personal_access_tokens.create(scopes: [:api], name: 'carmenauto'); token.set_token('$carmen_token'); token.save!"
-gitlab-rails runner "token = User.find_by_username('louis').personal_access_tokens.create(scopes: [:api], name: 'louisauto'); token.set_token('$louis_token'); token.save!"
+ashley_token=$(curl -X POST -H "PRIVATE-TOKEN: $1" --data "name=automation" --data "scopes[]=api" "http://localhost/api/v4/users/$ashley_id/personal_access_tokens" | jq -r '.token')
+mark_token=$(curl -X POST -H "PRIVATE-TOKEN: $1" --data "name=markauto" --data "scopes[]=api" "http://localhost/api/v4/users/$mark_id/personal_access_tokens" | jq -r '.token')
+carmen_token=$(curl -X POST -H "PRIVATE-TOKEN: $1" --data "name=carmenauto" --data "scopes[]=api" "http://localhost/api/v4/users/$carmen_id/personal_access_tokens" | jq -r '.token')
+sam_token=$(curl -X POST -H "PRIVATE-TOKEN: $1" --data "name=samauto" --data "scopes[]=api" "http://localhost/api/v4/users/$sam_id/personal_access_tokens" | jq -r '.token')
+louis_token=$(curl -X POST -H "PRIVATE-TOKEN: $1" --data "name=louisauto" --data "scopes[]=api" "http://localhost/api/v4/users/$louis_id/personal_access_tokens" | jq -r '.token')
+daniel_token=$(curl -X POST -H "PRIVATE-TOKEN: $1" --data "name=danielauto" --data "scopes[]=api" "http://localhost/api/v4/users/$daniel_id/personal_access_tokens" | jq -r '.token')
 
 # Create mvp-docker project
 curl -H "PRIVATE-TOKEN: $ashley_token" -X POST "http://localhost:80/api/v4/projects?name=mvp-docker&default_branch=main&import_url=https%3A%2F%2Fgithub.com%2FFrichetten%2Fmvp-docker&visibility=internal"


### PR DESCRIPTION
gitlab-rails is a very slow method for access token generation. Cut down deploy time by 1/3 by using the REST api instead