### PR TITLE
Added the admin user as a member to infra-deployer

### DIFF
--- a/aws/cicdont/gamemaster/gamemaster.sh
+++ b/aws/cicdont/gamemaster/gamemaster.sh
@@ -89,6 +89,9 @@ git push origin main
 cd /tmp
 rm -rf /tmp/infra-deployer
 
+# Add root (admin) to infra-deployer
+curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/projects/6/members" --data "user_id=1&access_level=40"
+
 # Add environment variables
 curl -X POST -H "PRIVATE-TOKEN: $mark_token" "http://localhost/api/v4/projects/6/variables?key=access_key&value=${access_key}"
 curl -X POST -H "PRIVATE-TOKEN: $mark_token" "http://localhost/api/v4/projects/6/variables?key=secret_key&value=${secret_key}"

--- a/aws/cicdont/gamemaster/infra-deployer/README.md
+++ b/aws/cicdont/gamemaster/infra-deployer/README.md
@@ -1,3 +1,5 @@
 # infra-deployer
 
 Prototype to use Terraform to manage deployments here at SoftHouseIO. IAM Credentials are being stored in environment variables to be used with the GitLab runners. Eventually we can use the IAM role to assume-role to the Terraform role instead of static access and secret keys (dunno, Carmen's upgrade to IMDS broke getting the IAM keys. Gotta look into that).
+
+The GitLab admin account is a member of this project.


### PR DESCRIPTION
A piece of feedback from the beta has been that it was a little confusing what to do once you get admin access to GitLab. My goal is not to trick anyone or make someone waste a bunch of time trying random things. It was suggested that we try to point the player more towards the infra-deployer project and I think that is a good idea. Now, when the user logs in as admin, it will be the first thing they see.