### PR TITLE
Added a 10 minute warning as an output

### DIFF
--- a/aws/cicdont/story.tf
+++ b/aws/cicdont/story.tf
@@ -33,3 +33,7 @@ resource "random_string" "gitlab_root_password" {
 output "attackbox_ip" {
   value = aws_instance.attackbox.public_ip
 }
+
+output "time_warning" {
+  value = "Please be aware the CTF will be ready 10 minutes from the time this message is first displayed"
+}


### PR DESCRIPTION
There was a miscommunication in the docs about how long it would take the infrastrcture to be ready. Some folks thought that once Terraform was done, it would be ready. To be fair, I didn't make it very clear. To try to alleviate this, I've added an output that will be displayed, reinforcing that it will take 10 minutes once Terraform was finished for the CTF to be ready