### PR TITLE
fix to Apple M1 compatibility

### DIFF
--- a/aws/cicdont/attackbox.tf
+++ b/aws/cicdont/attackbox.tf
@@ -47,14 +47,6 @@ resource "aws_security_group" "allow_inbound" {
   }
 }
 
-data "template_file" "attackbox_user_data" {
-  template = file("attackbox_user_data.sh")
-  vars = {
-    player_password = random_string.player_password.result
-    player_username = var.player_username
-  }
-}
-
 /* This is the host the player can attack/recieve shells from */
 resource "aws_instance" "attackbox" {
   ami                         = data.aws_ami.ubuntu_ami.id
@@ -64,7 +56,10 @@ resource "aws_instance" "attackbox" {
   vpc_security_group_ids      = [aws_security_group.allow_inbound.id]
   depends_on                  = [aws_internet_gateway.ctf_gw]
 
-  user_data = data.template_file.attackbox_user_data.rendered
+  user_data = templatefile("attackbox_user_data.sh", {
+    player_password = random_string.player_password.result
+    player_username = var.player_username
+  })
 
   tags = {
     Name = "attackbox"

--- a/aws/cicdont/gamemaster_s3_bucket.tf
+++ b/aws/cicdont/gamemaster_s3_bucket.tf
@@ -26,16 +26,11 @@ resource "aws_s3_bucket_object" "infra_deployer" {
 resource "aws_s3_bucket_object" "upload_gamemaster_script" {
   bucket  = aws_s3_bucket.gamemaster_bucket.id
   key     = "gamemaster.sh"
-  content = data.template_file.gamemaster_script.rendered
-}
-
-data "template_file" "gamemaster_script" {
-  template = file("./gamemaster/gamemaster.sh")
-  vars = {
+  content = templatefile("./gamemaster/gamemaster.sh", {
     gitlab_root_password = resource.random_string.gitlab_root_password.result
     player_username      = var.player_username
     player_password      = resource.random_string.player_password.result
     access_key           = aws_iam_access_key.aws_admin_user_access_key.id
     secret_key           = urlencode(aws_iam_access_key.aws_admin_user_access_key.secret)
-  }
+  })
 }

--- a/aws/cicdont/target_service.tf
+++ b/aws/cicdont/target_service.tf
@@ -46,16 +46,6 @@ resource "aws_security_group_rule" "allow_attackbox_inbound_rule" {
   cidr_blocks       = ["${aws_instance.attackbox.public_ip}/32"]
 }
 
-data "template_file" "target_user_data" {
-  template = file("target_service_user_data.sh")
-  vars = {
-    gitlab_root_password = resource.random_string.gitlab_root_password.result
-    player_username      = var.player_username
-    player_password      = resource.random_string.player_password.result
-    gamemaster_bucket    = aws_s3_bucket.gamemaster_bucket.id
-  }
-}
-
 /* This is the target of the ctf */
 resource "aws_instance" "target_service" {
   ami                         = data.aws_ami.ubuntu_ami.id
@@ -71,7 +61,12 @@ resource "aws_instance" "target_service" {
     volume_size = 24
   }
 
-  user_data = data.template_file.target_user_data.rendered
+  user_data = templatefile("target_service_user_data.sh", {
+    gitlab_root_password = resource.random_string.gitlab_root_password.result
+    player_username      = var.player_username
+    player_password      = resource.random_string.player_password.result
+    gamemaster_bucket    = aws_s3_bucket.gamemaster_bucket.id
+  })
 
   metadata_options {
     http_endpoint = "enabled"


### PR DESCRIPTION
Changed template provider to avoid compatibility issues with Apple M1.

```
➜  cicdont git:(main) terraform init

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/http from the dependency lock file
- Reusing previous version of hashicorp/aws from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Finding latest version of hashicorp/template...
- Using previously-installed hashicorp/random v3.4.3
- Using previously-installed hashicorp/http v3.1.0
- Using previously-installed hashicorp/aws v3.74.3
╷
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a
│ package available for your current platform, darwin_arm64.
│
│ Provider releases are separate from Terraform CLI releases, so not all
│ providers are available for all platforms. Other versions of this provider
│ may have different platforms supported.
╵
```