### PR TITLE
Fix admin PAT creation

### DIFF
--- a/aws/cicdont/target_service_user_data.sh
+++ b/aws/cicdont/target_service_user_data.sh
@@ -9,7 +9,7 @@ apt-get install -y curl openssh-server ca-certificates tzdata perl docker.io jq 
 curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | bash
 EXTERNAL_URL="http://$host_ip" GITLAB_ROOT_PASSWORD="${gitlab_root_password}" apt-get install gitlab-ee
 gitlab-rails runner 'ApplicationSetting.last.update(signup_enabled: false)'
-gitlab-rails runner "token = User.admins.last.personal_access_tokens.create(scopes: [:api], name: 'automation'); token.set_token('$admin_token'); token.save!"
+gitlab-rails runner "token = User.admins.last.personal_access_tokens.create(scopes: [:api], name: 'automation', expires_at: 365.days.from_now); token.set_token('$admin_token'); token.save!"
 sleep 2
 
 ## Install GitLab Runner


### PR DESCRIPTION
In `target_service_user_data.sh`, it seems that creating a GitLab personal token now requires an `expires_at` field or else it will fail, keeping the entire target service from coming up as later commands cannot authenticate using the token.

Sample log:
```
ubuntu@ip-10-0-0-128:~$ sudo gitlab-rails runner "token = User.admins.last.personal_access_tokens.create(scopes: [:api], name: 'automation'); token.set_token('<token>'); token.save!"
/opt/gitlab/embedded/lib/ruby/gems/3.1.0/gems/activerecord-7.0.8/lib/active_record/validations.rb:80:in `raise_validation_error': Validation failed: Expiration date can't be blank (ActiveRecord::RecordInvalid)
        from /opt/gitlab/embedded/lib/ruby/gems/3.1.0/gems/activerecord-7.0.8/lib/active_record/validations.rb:53:in `save!'
```

This PR adds the `expires_at` field and sets the token to expire a year from the creation date.