### PR TITLE
Explicitly add git as an import source and change project IDs

### DIFF
--- a/aws/cicdont/gamemaster/gamemaster.sh
+++ b/aws/cicdont/gamemaster/gamemaster.sh
@@ -90,14 +90,14 @@ cd /tmp
 rm -rf /tmp/infra-deployer
 
 # Add root (admin) to infra-deployer
-curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/projects/6/members" --data "user_id=1&access_level=40"
+curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/projects/5/members" --data "user_id=1&access_level=40"
 
 # Add environment variables
-curl -X POST -H "PRIVATE-TOKEN: $mark_token" "http://localhost/api/v4/projects/6/variables?key=access_key&value=${access_key}"
-curl -X POST -H "PRIVATE-TOKEN: $mark_token" "http://localhost/api/v4/projects/6/variables?key=secret_key&value=${secret_key}"
+curl -X POST -H "PRIVATE-TOKEN: $mark_token" "http://localhost/api/v4/projects/5/variables?key=access_key&value=${access_key}"
+curl -X POST -H "PRIVATE-TOKEN: $mark_token" "http://localhost/api/v4/projects/5/variables?key=secret_key&value=${secret_key}"
 
 # Assign the issue to the player
-curl -H "PRIVATE-TOKEN: $ashley_token" -X POST "http://localhost/api/v4/projects/2/issues?title=CI%2fCD%20Problem%20with%20Docker%20Container&assignee_id=8&description=Hey%20${player_username}%2C%20when%20you%20get%20a%20chance%20can%20you%20take%20a%20look%20at%20our%20CI%2FCD%20config%20%28gitlab-ci.yml%29%3F%20Something%20is%20going%20on%20with%20it.%20I%20was%20trying%20to%20build%20our%20new%20Docker%20container%20but%20it%20wasn%27t%20working%20right.%20Thanks%21"
+curl -H "PRIVATE-TOKEN: $ashley_token" -X POST "http://localhost/api/v4/projects/1/issues?title=CI%2fCD%20Problem%20with%20Docker%20Container&assignee_id=8&description=Hey%20${player_username}%2C%20when%20you%20get%20a%20chance%20can%20you%20take%20a%20look%20at%20our%20CI%2FCD%20config%20%28gitlab-ci.yml%29%3F%20Something%20is%20going%20on%20with%20it.%20I%20was%20trying%20to%20build%20our%20new%20Docker%20container%20but%20it%20wasn%27t%20working%20right.%20Thanks%21"
 
 # Change the login page
 curl -H "PRIVATE-TOKEN: $1" -X PUT "http://localhost/api/v4/application/appearance?title=SoftHouseIO%20GitLab%20Instance&description=The%20PREMERE%20web%20dev%20shop!%20If%20you%20need%20access%20talk%20to%20Mark."

--- a/aws/cicdont/gamemaster/gamemaster.sh
+++ b/aws/cicdont/gamemaster/gamemaster.sh
@@ -53,7 +53,7 @@ curl -H "PRIVATE-TOKEN: $sam_token" -X POST "http://localhost/api/v4/projects?na
 # Create Player
 player_id=$(curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/users?email=${player_username}@cloud.local&username=${player_username}&name=${player_username}&password=${player_password}&skip_confirmation=true" | jq -r '.id')
 # Add player to target_project
-curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/projects/2/members" --data "user_id=$player_id&access_level=40"
+curl -H "PRIVATE-TOKEN: $1" -X POST "http://localhost/api/v4/projects/1/members" --data "user_id=$player_id&access_level=40"
 
 # Adding Ashley's Joke Comment
 curl -H "PRIVATE-TOKEN: $ashley_token" -X POST "http://localhost/api/v4/projects/2/issues/1/notes?body=No."

--- a/aws/cicdont/target_service_user_data.sh
+++ b/aws/cicdont/target_service_user_data.sh
@@ -8,7 +8,7 @@ apt update
 apt-get install -y curl openssh-server ca-certificates tzdata perl docker.io jq awscli
 curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | bash
 EXTERNAL_URL="http://$host_ip" GITLAB_ROOT_PASSWORD="${gitlab_root_password}" apt-get install gitlab-ee
-gitlab-rails runner 'ApplicationSetting.last.update(signup_enabled: false)'
+gitlab-rails runner 'ApplicationSetting.last.update(signup_enabled: false, import_sources: ["git"])'
 gitlab-rails runner "token = User.admins.last.personal_access_tokens.create(scopes: [:api], name: 'automation', expires_at: 365.days.from_now); token.set_token('$admin_token'); token.save!"
 sleep 2
 


### PR DESCRIPTION
`940dbef`: GitLab seems to have added a new check preventing projects from being created with `import_url` unless the `git` ("Import Repository from URL") source has been added, meaning that Ashley's projects are never created (403 Forbidden). It seems like GitLab really likes breaking things, maybe pinning the version might help with this in the future?

`27ecee5`, `d2815b6`: Mark's `infra-deployer` project is created at project ID 5 but the variables are added to project 6, which doesn't exist at the time, so they are not added. Ashley's interactions with the player also use project 2, but the `mvp-docker` project is project 1.

I was able to complete the walkthrough after making these changes!