### PR TITLE
Pinned GitLab version

### DIFF
--- a/aws/cicdont/target_service_user_data.sh
+++ b/aws/cicdont/target_service_user_data.sh
@@ -7,7 +7,7 @@ admin_token=$(openssl rand -hex 20)
 apt update
 apt-get install -y curl openssh-server ca-certificates tzdata perl docker.io jq awscli
 curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | bash
-EXTERNAL_URL="http://$host_ip" GITLAB_ROOT_PASSWORD="${gitlab_root_password}" apt-get install gitlab-ee
+EXTERNAL_URL="http://$host_ip" GITLAB_ROOT_PASSWORD="${gitlab_root_password}" apt-get install gitlab-ee=16.9.1-ee.0
 gitlab-rails runner 'ApplicationSetting.last.update(signup_enabled: false, import_sources: ["git"])'
 gitlab-rails runner "token = User.admins.last.personal_access_tokens.create(scopes: [:api], name: 'automation', expires_at: 365.days.from_now); token.set_token('$admin_token'); token.save!"
 sleep 2


### PR DESCRIPTION
Pinning the version of GitLab installed. It looks like GitLab made several changes to the API which broke the CTF. 